### PR TITLE
Fix for Astral Recall and some other spells not appearing

### DIFF
--- a/Broker_Portals/portals.lua
+++ b/Broker_Portals/portals.lua
@@ -215,8 +215,8 @@ local function SetupSpells()
     else
       portals = {};
     end
-    tinsert(portals, { 18960 })
-    tinsert(portals, { 556 })
+    tinsert(portals, { 18960 }) -- TP:Moonglade
+    tinsert(portals, { 556 }) -- Astral Recall
   end
   if class == 'MAGE' then
     portals = spells[fac]
@@ -226,11 +226,11 @@ local function SetupSpells()
     }
   elseif class == 'DRUID' then
     portals = {
-      { 18960 } -- TP:Moonglade
+      { 18960 }
     }
   elseif class == 'SHAMAN' then
     portals = {
-      { 556 } -- Astral Recall
+      { 556 }
     }
   end
   -- Ascension: Stones of Retreat
@@ -328,20 +328,19 @@ local function UpdateSpells()
       local spellid = findSpell(spell)
 
       if spellid then
-        if PortalsDB.showPortals and v[2] and not (GetNumPartyMembers() > 0 or UnitInRaid("player")) then
-          break
-        end
-        methods[spell] = {
-          spellid = spellid,
-          text = spell,
-          spellIcon = spellIcon,
-          isPortal = v[2],
-          secure = {
-            type = 'spell',
-            spell = spell
+        if not PortalsDB.showPortals or not v[2] or (GetNumPartyMembers() > 0 or UnitInRaid("player")) then
+          methods[spell] = {
+            spellid = spellid,
+            text = spell,
+            spellIcon = spellIcon,
+            isPortal = v[2],
+            secure = {
+              type = 'spell',
+              spell = spell
+            }
           }
-        }
-        i = i + 1
+          i = i + 1
+        end
       end
     end
   end

--- a/Broker_Portals/portals.lua
+++ b/Broker_Portals/portals.lua
@@ -316,7 +316,6 @@ local function SetupSpells()
   if #runeRandom > 0 then
     tinsert(portals, { runeRandom[math.random(1, #runeRandom)], 'TRUE' })
   end
-  spells = nil
 end
 
 local function UpdateSpells()


### PR DESCRIPTION
This was happening due to a break in a loop that wasn't supposed to be there, my mistake.
Replaced by inverting the `if` block since we don't have a `continue()` in LUA.
 
So essentially let's say that our var `spells` was the following:
```lua
spells = {
  { 3561 }, -- TP:Stormwind
  { 10059, 'TRUE' }, -- P:Stormwind
  { 556 } -- Astral Recall
}
```

When the loop would reach a portal so in this e.g portal to Stormwind, everything below would be hidden if the option `Show portals only in Party/Raid`.